### PR TITLE
Add box-sizing of content-box to .add-on

### DIFF
--- a/tx_highered/static/tx_highered/vendor/bootstrap/build.sh
+++ b/tx_highered/static/tx_highered/vendor/bootstrap/build.sh
@@ -1,1 +1,1 @@
- sass  --update scss/bootstrap.scss:css/ttstrap.css
+sass  --update scss/bootstrap.scss:css/ttstrap.css

--- a/tx_highered/static/tx_highered/vendor/bootstrap/css/ttstrap.css
+++ b/tx_highered/static/tx_highered/vendor/bootstrap/css/ttstrap.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * Bootstrap v2.0.4
  *
  * Copyright 2012 Twitter, Inc
@@ -36,43 +36,8 @@
   font-family: Georgia, "Times New Roman", Times, serif;
   font-size: 15px;
   line-height: 20px;
-  color: #333333;
-  background-color: white;
-  @-webkit-keyframes progress-bar-stripes {
-    from {
-      background-position: 40px 0; }
-
-    to {
-      background-position: 0 0; } }
-
-  @-moz-keyframes progress-bar-stripes {
-    from {
-      background-position: 40px 0; }
-
-    to {
-      background-position: 0 0; } }
-
-  @-ms-keyframes progress-bar-stripes {
-    from {
-      background-position: 40px 0; }
-
-    to {
-      background-position: 0 0; } }
-
-  @-o-keyframes progress-bar-stripes {
-    from {
-      background-position: 0 0; }
-
-    to {
-      background-position: 40px 0; } }
-
-  @keyframes progress-bar-stripes {
-    from {
-      background-position: 40px 0; }
-
-    to {
-      background-position: 0 0; } }
- }
+  color: #333;
+  background-color: #fff; }
   .bootstrap article,
   .bootstrap aside,
   .bootstrap details,
@@ -159,8 +124,8 @@
     font-family: Georgia, "Times New Roman", Times, serif;
     font-size: 15px;
     line-height: 20px;
-    color: #333333;
-    background-color: white; }
+    color: #333;
+    background-color: #fff; }
   .bootstrap a {
     color: #008990;
     text-decoration: none; }
@@ -309,7 +274,7 @@
     margin: 0 0 10px; }
     .bootstrap p small {
       font-size: 13px;
-      color: #999999; }
+      color: #999; }
   .bootstrap .lead {
     margin-bottom: 20px;
     font-size: 20px;
@@ -323,7 +288,7 @@
     text-rendering: optimizelegibility; }
     .bootstrap h1 small, .bootstrap h2 small, .bootstrap h3 small, .bootstrap h4 small, .bootstrap h5 small, .bootstrap h6 small {
       font-weight: normal;
-      color: #999999; }
+      color: #999; }
   .bootstrap h1 {
     font-size: 30px;
     line-height: 40px; }
@@ -349,12 +314,12 @@
     font-size: 12px; }
   .bootstrap h6 {
     font-size: 11px;
-    color: #999999;
+    color: #999;
     text-transform: uppercase; }
   .bootstrap .page-header {
     padding-bottom: 9px;
     margin: 10px 0;
-    border-bottom: 1px solid #999999; }
+    border-bottom: 1px solid #999; }
   .bootstrap .page-header h1 {
     line-height: 1; }
   .bootstrap ul, .bootstrap ol {
@@ -398,24 +363,24 @@
   .bootstrap hr {
     margin: 20px 0;
     border: 0;
-    border-top: 1px solid #eeeeee;
-    border-bottom: 1px solid white; }
+    border-top: 1px solid #eee;
+    border-bottom: 1px solid #fff; }
   .bootstrap strong {
     font-weight: bold; }
   .bootstrap em {
     font-style: italic; }
   .bootstrap .muted {
-    color: #999999; }
+    color: #999; }
   .bootstrap abbr[title] {
     cursor: help;
-    border-bottom: 1px dotted #999999; }
+    border-bottom: 1px dotted #999; }
   .bootstrap abbr.initialism {
     font-size: 90%;
     text-transform: uppercase; }
   .bootstrap blockquote {
     padding: 0 0 0 15px;
     margin: 0 0 20px;
-    border-left: 5px solid #eeeeee; }
+    border-left: 5px solid #eee; }
     .bootstrap blockquote p {
       margin-bottom: 0;
       font-size: 16px;
@@ -424,14 +389,14 @@
     .bootstrap blockquote small {
       display: block;
       line-height: 20px;
-      color: #999999; }
+      color: #999; }
       .bootstrap blockquote small:before {
         content: '\2014 \00A0'; }
     .bootstrap blockquote.pull-right {
       float: right;
       padding-right: 15px;
       padding-left: 0;
-      border-right: 5px solid #eeeeee;
+      border-right: 5px solid #eee;
       border-left: 0; }
       .bootstrap blockquote.pull-right p,
       .bootstrap blockquote.pull-right small {
@@ -455,7 +420,7 @@
     padding: 0 3px 2px;
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
     font-size: 14px;
-    color: #333333;
+    color: #333;
     -webkit-border-radius: 3px;
     -moz-border-radius: 3px;
     border-radius: 3px; }
@@ -503,12 +468,12 @@
     margin-bottom: 30px;
     font-size: 22.5px;
     line-height: 40px;
-    color: #333333;
+    color: #333;
     border: 0;
     border-bottom: 1px solid #e5e5e5; }
     .bootstrap legend small {
       font-size: 15px;
-      color: #999999; }
+      color: #999; }
   .bootstrap label,
   .bootstrap input,
   .bootstrap button,
@@ -548,7 +513,7 @@
     margin-bottom: 9px;
     font-size: 15px;
     line-height: 20px;
-    color: #555555; }
+    color: #555; }
   .bootstrap input,
   .bootstrap textarea {
     width: 210px; }
@@ -570,8 +535,8 @@
   .bootstrap input[type="tel"],
   .bootstrap input[type="color"],
   .bootstrap .uneditable-input {
-    background-color: white;
-    border: 1px solid #cccccc;
+    background-color: #fff;
+    border: 1px solid #ccc;
     -webkit-border-radius: 3px;
     -moz-border-radius: 3px;
     border-radius: 3px;
@@ -702,7 +667,7 @@
   .bootstrap select[readonly],
   .bootstrap textarea[readonly] {
     cursor: not-allowed;
-    background-color: #eeeeee;
+    background-color: #eee;
     border-color: #ddd; }
   .bootstrap input[type="radio"][disabled],
   .bootstrap input[type="checkbox"][disabled],
@@ -800,7 +765,7 @@
     padding: 19px 20px 20px;
     margin-top: 20px;
     margin-bottom: 20px;
-    background-color: whitesmoke;
+    background-color: #f5f5f5;
     border-top: 1px solid #e5e5e5;
     *zoom: 1; }
     .bootstrap .form-actions:before, .bootstrap .form-actions:after {
@@ -812,20 +777,20 @@
     overflow: hidden;
     white-space: nowrap;
     cursor: not-allowed;
-    background-color: white;
+    background-color: #fff;
     border-color: #eee;
     -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.025);
     -moz-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.025);
     box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.025); }
   .bootstrap :-moz-placeholder {
-    color: #999999; }
+    color: #999; }
   .bootstrap :-ms-input-placeholder {
-    color: #999999; }
+    color: #999; }
   .bootstrap ::-webkit-input-placeholder {
-    color: #999999; }
+    color: #999; }
   .bootstrap .help-block,
   .bootstrap .help-inline {
-    color: #555555; }
+    color: #555; }
   .bootstrap .help-block {
     display: block;
     margin-bottom: 10px; }
@@ -863,6 +828,7 @@
       border-left-color: #ccc; }
     .bootstrap .input-prepend .add-on,
     .bootstrap .input-append .add-on {
+      box-sizing: content-box;
       display: inline-block;
       width: auto;
       height: 20px;
@@ -872,9 +838,9 @@
       font-weight: normal;
       line-height: 20px;
       text-align: center;
-      text-shadow: 0 1px 0 white;
+      text-shadow: 0 1px 0 #fff;
       vertical-align: middle;
-      background-color: #eeeeee;
+      background-color: #eee;
       border: 1px solid #ccc; }
     .bootstrap .input-prepend .add-on,
     .bootstrap .input-prepend .btn,
@@ -1033,7 +999,7 @@
       line-height: 20px;
       text-align: left;
       vertical-align: top;
-      border-top: 1px solid #dddddd; }
+      border-top: 1px solid #ddd; }
     .bootstrap .table th {
       font-weight: bold; }
     .bootstrap .table thead th {
@@ -1046,12 +1012,12 @@
     .bootstrap .table thead:first-child tr:first-child td {
       border-top: 0; }
     .bootstrap .table tbody + tbody {
-      border-top: 2px solid #dddddd; }
+      border-top: 2px solid #ddd; }
   .bootstrap .table-condensed th,
   .bootstrap .table-condensed td {
     padding: 4px 5px; }
   .bootstrap .table-bordered {
-    border: 1px solid #dddddd;
+    border: 1px solid #ddd;
     border-collapse: separate;
     *border-collapse: collapsed;
     border-left: 0;
@@ -1060,7 +1026,7 @@
     border-radius: 4px; }
     .bootstrap .table-bordered th,
     .bootstrap .table-bordered td {
-      border-left: 1px solid #dddddd; }
+      border-left: 1px solid #ddd; }
     .bootstrap .table-bordered caption + thead tr:first-child th,
     .bootstrap .table-bordered caption + tbody tr:first-child th,
     .bootstrap .table-bordered caption + tbody tr:first-child td,
@@ -1099,7 +1065,7 @@
     background-color: #f9f9f9; }
   .bootstrap .table tbody tr:hover td,
   .bootstrap .table tbody tr:hover th {
-    background-color: whitesmoke; }
+    background-color: #f5f5f5; }
   .bootstrap table .span1 {
     float: none;
     width: 53px;
@@ -1215,13 +1181,13 @@
   .bootstrap .icon-glass {
     background-position: 0      0; }
   .bootstrap .icon-music {
-    background-position: -24px 0; }
+    background-position: -24px  0; }
   .bootstrap .icon-search {
-    background-position: -48px 0; }
+    background-position: -48px  0; }
   .bootstrap .icon-envelope {
-    background-position: -72px 0; }
+    background-position: -72px  0; }
   .bootstrap .icon-heart {
-    background-position: -96px 0; }
+    background-position: -96px  0; }
   .bootstrap .icon-star {
     background-position: -120px 0; }
   .bootstrap .icon-star-empty {
@@ -1253,15 +1219,15 @@
   .bootstrap .icon-trash {
     background-position: -456px 0; }
   .bootstrap .icon-home {
-    background-position: 0 -24px; }
+    background-position: 0      -24px; }
   .bootstrap .icon-file {
-    background-position: -24px -24px; }
+    background-position: -24px  -24px; }
   .bootstrap .icon-time {
-    background-position: -48px -24px; }
+    background-position: -48px  -24px; }
   .bootstrap .icon-road {
-    background-position: -72px -24px; }
+    background-position: -72px  -24px; }
   .bootstrap .icon-download-alt {
-    background-position: -96px -24px; }
+    background-position: -96px  -24px; }
   .bootstrap .icon-download {
     background-position: -120px -24px; }
   .bootstrap .icon-upload {
@@ -1293,15 +1259,15 @@
   .bootstrap .icon-barcode {
     background-position: -456px -24px; }
   .bootstrap .icon-tag {
-    background-position: 0 -48px; }
+    background-position: 0      -48px; }
   .bootstrap .icon-tags {
-    background-position: -25px -48px; }
+    background-position: -25px  -48px; }
   .bootstrap .icon-book {
-    background-position: -48px -48px; }
+    background-position: -48px  -48px; }
   .bootstrap .icon-bookmark {
-    background-position: -72px -48px; }
+    background-position: -72px  -48px; }
   .bootstrap .icon-print {
-    background-position: -96px -48px; }
+    background-position: -96px  -48px; }
   .bootstrap .icon-camera {
     background-position: -120px -48px; }
   .bootstrap .icon-font {
@@ -1333,15 +1299,15 @@
   .bootstrap .icon-picture {
     background-position: -456px -48px; }
   .bootstrap .icon-pencil {
-    background-position: 0 -72px; }
+    background-position: 0      -72px; }
   .bootstrap .icon-map-marker {
-    background-position: -24px -72px; }
+    background-position: -24px  -72px; }
   .bootstrap .icon-adjust {
-    background-position: -48px -72px; }
+    background-position: -48px  -72px; }
   .bootstrap .icon-tint {
-    background-position: -72px -72px; }
+    background-position: -72px  -72px; }
   .bootstrap .icon-edit {
-    background-position: -96px -72px; }
+    background-position: -96px  -72px; }
   .bootstrap .icon-share {
     background-position: -120px -72px; }
   .bootstrap .icon-check {
@@ -1373,15 +1339,15 @@
   .bootstrap .icon-chevron-right {
     background-position: -456px -72px; }
   .bootstrap .icon-plus-sign {
-    background-position: 0 -96px; }
+    background-position: 0      -96px; }
   .bootstrap .icon-minus-sign {
-    background-position: -24px -96px; }
+    background-position: -24px  -96px; }
   .bootstrap .icon-remove-sign {
-    background-position: -48px -96px; }
+    background-position: -48px  -96px; }
   .bootstrap .icon-ok-sign {
-    background-position: -72px -96px; }
+    background-position: -72px  -96px; }
   .bootstrap .icon-question-sign {
-    background-position: -96px -96px; }
+    background-position: -96px  -96px; }
   .bootstrap .icon-info-sign {
     background-position: -120px -96px; }
   .bootstrap .icon-screenshot {
@@ -1413,15 +1379,15 @@
   .bootstrap .icon-asterisk {
     background-position: -456px -96px; }
   .bootstrap .icon-exclamation-sign {
-    background-position: 0 -120px; }
+    background-position: 0      -120px; }
   .bootstrap .icon-gift {
-    background-position: -24px -120px; }
+    background-position: -24px  -120px; }
   .bootstrap .icon-leaf {
-    background-position: -48px -120px; }
+    background-position: -48px  -120px; }
   .bootstrap .icon-fire {
-    background-position: -72px -120px; }
+    background-position: -72px  -120px; }
   .bootstrap .icon-eye-open {
-    background-position: -96px -120px; }
+    background-position: -96px  -120px; }
   .bootstrap .icon-eye-close {
     background-position: -120px -120px; }
   .bootstrap .icon-warning-sign {
@@ -1453,15 +1419,15 @@
   .bootstrap .icon-resize-horizontal {
     background-position: -456px -118px; }
   .bootstrap .icon-hdd {
-    background-position: 0 -144px; }
+    background-position: 0      -144px; }
   .bootstrap .icon-bullhorn {
-    background-position: -24px -144px; }
+    background-position: -24px  -144px; }
   .bootstrap .icon-bell {
-    background-position: -48px -144px; }
+    background-position: -48px  -144px; }
   .bootstrap .icon-certificate {
-    background-position: -72px -144px; }
+    background-position: -72px  -144px; }
   .bootstrap .icon-thumbs-up {
-    background-position: -96px -144px; }
+    background-position: -96px  -144px; }
   .bootstrap .icon-thumbs-down {
     background-position: -120px -144px; }
   .bootstrap .icon-hand-right {
@@ -1505,7 +1471,7 @@
     width: 0;
     height: 0;
     vertical-align: top;
-    border-top: 4px solid black;
+    border-top: 4px solid #000;
     border-right: 4px solid transparent;
     border-left: 4px solid transparent;
     content: "";
@@ -1529,7 +1495,7 @@
     padding: 4px 0;
     margin: 1px 0 0;
     list-style: none;
-    background-color: white;
+    background-color: #fff;
     border: 1px solid #ccc;
     border: 1px solid rgba(0, 0, 0, 0.2);
     *border-right-width: 2px;
@@ -1553,19 +1519,19 @@
       *margin: -5px 0 5px;
       overflow: hidden;
       background-color: #e5e5e5;
-      border-bottom: 1px solid white; }
+      border-bottom: 1px solid #fff; }
     .bootstrap .dropdown-menu a {
       display: block;
       padding: 3px 15px;
       clear: both;
       font-weight: normal;
       line-height: 20px;
-      color: #333333;
+      color: #333;
       white-space: nowrap; }
   .bootstrap .dropdown-menu li > a:hover,
   .bootstrap .dropdown-menu .active > a,
   .bootstrap .dropdown-menu .active > a:hover {
-    color: white;
+    color: #fff;
     text-decoration: none;
     background-color: #008990; }
   .bootstrap .open {
@@ -1578,7 +1544,7 @@
   .bootstrap .dropup .caret,
   .bootstrap .navbar-fixed-bottom .dropdown .caret {
     border-top: 0;
-    border-bottom: 4px solid black;
+    border-bottom: 4px solid #000;
     content: "\2191"; }
   .bootstrap .dropup .dropdown-menu,
   .bootstrap .navbar-fixed-bottom .dropdown .dropdown-menu {
@@ -1643,12 +1609,12 @@
     font-size: 20px;
     font-weight: bold;
     line-height: 20px;
-    color: black;
+    color: #000;
     text-shadow: 0 1px 0 white;
     opacity: 0.2;
     filter: alpha(opacity=20); }
     .bootstrap .close:hover {
-      color: black;
+      color: #000;
       text-decoration: none;
       cursor: pointer;
       opacity: 0.4;
@@ -1668,18 +1634,18 @@
     font-size: 15px;
     line-height: 20px;
     *line-height: 20px;
-    color: #333333;
+    color: #333;
     text-align: center;
     text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
     vertical-align: middle;
     cursor: pointer;
     background-color: whitesmoke;
-    background-image: -moz-linear-gradient(top, white, #e6e6e6);
-    background-image: -ms-linear-gradient(top, white, #e6e6e6);
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(white), to(#e6e6e6));
-    background-image: -webkit-linear-gradient(top, white, #e6e6e6);
-    background-image: -o-linear-gradient(top, white, #e6e6e6);
-    background-image: linear-gradient(top, white, #e6e6e6);
+    background-image: -moz-linear-gradient(top, #fff, #e6e6e6);
+    background-image: -ms-linear-gradient(top, #fff, #e6e6e6);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#fff), to(#e6e6e6));
+    background-image: -webkit-linear-gradient(top, #fff, #e6e6e6);
+    background-image: -o-linear-gradient(top, #fff, #e6e6e6);
+    background-image: linear-gradient(top, #fff, #e6e6e6);
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#e3e3e3', GradientType=0);
     border-color: #e6e6e6 #e6e6e6 #bfbfbf;
@@ -1687,7 +1653,7 @@
     *background-color: #e6e6e6;
     /* Darken IE7 buttons by default so they stand out more given they won't have borders */
     filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
-    border: 1px solid #cccccc;
+    border: 1px solid #ccc;
     *border: 0;
     border-bottom-color: #b3b3b3;
     -webkit-border-radius: 4px;
@@ -1705,7 +1671,7 @@
     .bootstrap .btn:first-child {
       *margin-left: 0; }
   .bootstrap .btn:hover {
-    color: #333333;
+    color: #333;
     text-decoration: none;
     background-color: #e6e6e6;
     *background-color: #d9d9d9;
@@ -1770,7 +1736,7 @@
   .bootstrap .btn-info:hover,
   .bootstrap .btn-inverse,
   .bootstrap .btn-inverse:hover {
-    color: white;
+    color: #fff;
     text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25); }
   .bootstrap .btn-primary.active,
   .bootstrap .btn-warning.active,
@@ -1884,21 +1850,21 @@
       background-color: #24748c \9; }
   .bootstrap .btn-inverse {
     background-color: #404040;
-    background-image: -moz-linear-gradient(top, #555555, #222222);
-    background-image: -ms-linear-gradient(top, #555555, #222222);
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#555555), to(#222222));
-    background-image: -webkit-linear-gradient(top, #555555, #222222);
-    background-image: -o-linear-gradient(top, #555555, #222222);
-    background-image: linear-gradient(top, #555555, #222222);
+    background-image: -moz-linear-gradient(top, #555, #222);
+    background-image: -ms-linear-gradient(top, #555, #222);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#555), to(#222));
+    background-image: -webkit-linear-gradient(top, #555, #222);
+    background-image: -o-linear-gradient(top, #555, #222);
+    background-image: linear-gradient(top, #555, #222);
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#525252', endColorstr='#1f1f1f', GradientType=0);
-    border-color: #222222 #222222 black;
+    border-color: #222 #222 black;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-    *background-color: #222222;
+    *background-color: #222;
     /* Darken IE7 buttons by default so they stand out more given they won't have borders */
     filter: progid:DXImageTransform.Microsoft.gradient(enabled=false); }
     .bootstrap .btn-inverse:hover, .bootstrap .btn-inverse:active, .bootstrap .btn-inverse.active, .bootstrap .btn-inverse.disabled, .bootstrap .btn-inverse[disabled] {
-      background-color: #222222;
+      background-color: #222;
       *background-color: #151515; }
     .bootstrap .btn-inverse:active, .bootstrap .btn-inverse.active {
       background-color: #090909 \9; }
@@ -1937,7 +1903,7 @@
     *background-color: #2d4373;
     /* Darken IE7 buttons by default so they stand out more given they won't have borders */
     filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
-    color: #eeeeee;
+    color: #eee;
     text-shadow: 0 0 0; }
     .bootstrap .btn-facebook:hover, .bootstrap .btn-facebook:active, .bootstrap .btn-facebook.active, .bootstrap .btn-facebook.disabled, .bootstrap .btn-facebook[disabled] {
       background-color: #2d4373;
@@ -1945,7 +1911,7 @@
     .bootstrap .btn-facebook:active, .bootstrap .btn-facebook.active {
       background-color: #1e2e4f \9; }
     .bootstrap .btn-facebook:hover {
-      color: white; }
+      color: #fff; }
   .bootstrap .btn-twitter {
     background-color: #3b96ff;
     background-image: -moz-linear-gradient(top, #5aa7ff, #0d7eff);
@@ -1961,7 +1927,7 @@
     *background-color: #0d7eff;
     /* Darken IE7 buttons by default so they stand out more given they won't have borders */
     filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
-    color: #eeeeee;
+    color: #eee;
     text-shadow: 0 0 0; }
     .bootstrap .btn-twitter:hover, .bootstrap .btn-twitter:active, .bootstrap .btn-twitter.active, .bootstrap .btn-twitter.disabled, .bootstrap .btn-twitter[disabled] {
       background-color: #0d7eff;
@@ -1969,7 +1935,7 @@
     .bootstrap .btn-twitter:active, .bootstrap .btn-twitter.active {
       background-color: #0065d9 \9; }
     .bootstrap .btn-twitter:hover {
-      color: white; }
+      color: #fff; }
   .bootstrap button.btn,
   .bootstrap input[type="submit"].btn {
     *padding-top: 2px;
@@ -2092,7 +2058,7 @@
   .bootstrap .btn-group.open .btn-info.dropdown-toggle {
     background-color: #2f96b4; }
   .bootstrap .btn-group.open .btn-inverse.dropdown-toggle {
-    background-color: #222222; }
+    background-color: #222; }
   .bootstrap .btn .caret {
     margin-top: 7px;
     margin-left: 0; }
@@ -2110,7 +2076,7 @@
     border-right-width: 5px;
     border-top-width: 5px; }
   .bootstrap .dropup .btn-large .caret {
-    border-bottom: 5px solid black;
+    border-bottom: 5px solid #000;
     border-top: 0; }
   .bootstrap .btn-primary .caret,
   .bootstrap .btn-warning .caret,
@@ -2118,8 +2084,8 @@
   .bootstrap .btn-info .caret,
   .bootstrap .btn-success .caret,
   .bootstrap .btn-inverse .caret {
-    border-top-color: white;
-    border-bottom-color: white;
+    border-top-color: #fff;
+    border-bottom-color: #fff;
     opacity: 0.75;
     filter: alpha(opacity=75); }
   .bootstrap .alert {
@@ -2168,7 +2134,7 @@
     display: block; }
   .bootstrap .nav > li > a:hover {
     text-decoration: none;
-    background-color: #eeeeee; }
+    background-color: #eee; }
   .bootstrap .nav > .pull-right {
     float: right; }
   .bootstrap .nav .nav-header {
@@ -2177,7 +2143,7 @@
     font-size: 11px;
     font-weight: bold;
     line-height: 20px;
-    color: #999999;
+    color: #999;
     text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
     text-transform: uppercase; }
   .bootstrap .nav li + .nav-header {
@@ -2195,7 +2161,7 @@
     padding: 3px 15px; }
   .bootstrap .nav-list > .active > a,
   .bootstrap .nav-list > .active > a:hover {
-    color: white;
+    color: #fff;
     text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.2);
     background-color: #008990; }
   .bootstrap .nav-list [class^="icon-"] {
@@ -2207,7 +2173,7 @@
     *margin: -5px 0 5px;
     overflow: hidden;
     background-color: #e5e5e5;
-    border-bottom: 1px solid white; }
+    border-bottom: 1px solid #fff; }
   .bootstrap .nav-tabs,
   .bootstrap .nav-pills {
     *zoom: 1; }
@@ -2241,11 +2207,11 @@
     -moz-border-radius: 4px 4px 0 0;
     border-radius: 4px 4px 0 0; }
     .bootstrap .nav-tabs > li > a:hover {
-      border-color: #eeeeee #eeeeee #dddddd; }
+      border-color: #eee #eee #ddd; }
   .bootstrap .nav-tabs > .active > a,
   .bootstrap .nav-tabs > .active > a:hover {
-    color: #555555;
-    background-color: white;
+    color: #555;
+    background-color: #fff;
     border: 1px solid #ddd;
     border-bottom-color: transparent;
     cursor: default; }
@@ -2259,7 +2225,7 @@
     border-radius: 5px; }
   .bootstrap .nav-pills > .active > a,
   .bootstrap .nav-pills > .active > a:hover {
-    color: white;
+    color: #fff;
     background-color: #008990; }
   .bootstrap .nav-stacked > li {
     float: none; }
@@ -2306,26 +2272,26 @@
     border-bottom-color: #004044; }
   .bootstrap .nav-tabs .active .dropdown-toggle .caret,
   .bootstrap .nav-pills .active .dropdown-toggle .caret {
-    border-top-color: #333333;
-    border-bottom-color: #333333; }
+    border-top-color: #333;
+    border-bottom-color: #333; }
   .bootstrap .nav > .dropdown.active > a:hover {
-    color: black;
+    color: #000;
     cursor: pointer; }
   .bootstrap .nav-tabs .open .dropdown-toggle,
   .bootstrap .nav-pills .open .dropdown-toggle,
   .bootstrap .nav > li.dropdown.open.active > a:hover {
-    color: white;
-    background-color: #999999;
-    border-color: #999999; }
+    color: #fff;
+    background-color: #999;
+    border-color: #999; }
   .bootstrap .nav li.dropdown.open .caret,
   .bootstrap .nav li.dropdown.open.active .caret,
   .bootstrap .nav li.dropdown.open a:hover .caret {
-    border-top-color: white;
-    border-bottom-color: white;
+    border-top-color: #fff;
+    border-bottom-color: #fff;
     opacity: 1;
     filter: alpha(opacity=100); }
   .bootstrap .tabs-stacked .open > a:hover {
-    border-color: #999999; }
+    border-color: #999; }
   .bootstrap .tabbable {
     *zoom: 1; }
     .bootstrap .tabbable:before, .bootstrap .tabbable:after {
@@ -2378,11 +2344,11 @@
     -moz-border-radius: 4px 0 0 4px;
     border-radius: 4px 0 0 4px; }
   .bootstrap .tabs-left > .nav-tabs > li > a:hover {
-    border-color: #eeeeee #dddddd #eeeeee #eeeeee; }
+    border-color: #eee #ddd #eee #eee; }
   .bootstrap .tabs-left > .nav-tabs .active > a,
   .bootstrap .tabs-left > .nav-tabs .active > a:hover {
     border-color: #ddd transparent #ddd #ddd;
-    *border-right-color: white; }
+    *border-right-color: #fff; }
   .bootstrap .tabs-right > .nav-tabs {
     float: right;
     margin-left: 19px;
@@ -2393,11 +2359,11 @@
     -moz-border-radius: 0 4px 4px 0;
     border-radius: 0 4px 4px 0; }
   .bootstrap .tabs-right > .nav-tabs > li > a:hover {
-    border-color: #eeeeee #eeeeee #eeeeee #dddddd; }
+    border-color: #eee #eee #eee #ddd; }
   .bootstrap .tabs-right > .nav-tabs .active > a,
   .bootstrap .tabs-right > .nav-tabs .active > a:hover {
     border-color: #ddd #ddd #ddd transparent;
-    *border-left-color: white; }
+    *border-left-color: #fff; }
   .bootstrap .navbar {
     *position: relative;
     *z-index: 2;
@@ -2407,12 +2373,12 @@
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     min-height: 30px;
     background-color: #404040;
-    background-image: -moz-linear-gradient(top, #555555, #222222);
-    background-image: -ms-linear-gradient(top, #555555, #222222);
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#555555), to(#222222));
-    background-image: -webkit-linear-gradient(top, #555555, #222222);
-    background-image: -o-linear-gradient(top, #555555, #222222);
-    background-image: linear-gradient(top, #555555, #222222);
+    background-image: -moz-linear-gradient(top, #555, #222);
+    background-image: -ms-linear-gradient(top, #555, #222);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#555), to(#222));
+    background-image: -webkit-linear-gradient(top, #555, #222);
+    background-image: -o-linear-gradient(top, #555, #222);
+    background-image: linear-gradient(top, #555, #222);
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#525252', endColorstr='#1f1f1f', GradientType=0); }
   .bootstrap .navbar .container {
@@ -2420,7 +2386,7 @@
   .bootstrap .nav-collapse.collapse {
     height: auto; }
   .bootstrap .navbar {
-    color: #eeeeee;
+    color: #eee;
     margin-bottom: 10px; }
     .bootstrap .navbar .brand:hover {
       text-decoration: none; }
@@ -2432,12 +2398,12 @@
       font-size: 20px;
       font-weight: 200;
       line-height: 1;
-      color: #eeeeee; }
+      color: #eee; }
     .bootstrap .navbar .navbar-text {
       margin-bottom: 0;
       line-height: 30px; }
     .bootstrap .navbar .navbar-link {
-      color: #eeeeee; }
+      color: #eee; }
       .bootstrap .navbar .navbar-link:hover {
         color: #ffcc20; }
     .bootstrap .navbar .btn,
@@ -2489,21 +2455,21 @@
       line-height: 1;
       background-color: #fafafa;
       border: 1px solid #adadad;
-      color: #333333;
+      color: #333;
       height: auto;
       margin-bottom: 0;
       padding: 3px 9px; }
       .bootstrap .navbar-search .search-query :-moz-placeholder {
-        color: #555555; }
+        color: #555; }
       .bootstrap .navbar-search .search-query :-ms-input-placeholder {
-        color: #555555; }
+        color: #555; }
       .bootstrap .navbar-search .search-query ::-webkit-input-placeholder {
-        color: #555555; }
+        color: #555; }
       .bootstrap .navbar-search .search-query:focus, .bootstrap .navbar-search .search-query.focused {
         padding: 5px 10px;
-        color: #333333;
-        text-shadow: 0 1px 0 white;
-        background-color: white;
+        color: #333;
+        text-shadow: 0 1px 0 #fff;
+        background-color: #fff;
         border: 0;
         -webkit-box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
         -moz-box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
@@ -2543,7 +2509,7 @@
     padding: 0 10px;
     font-size: 11px;
     line-height: 30px;
-    color: #eeeeee;
+    color: #eee;
     text-decoration: none;
     text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25); }
   .bootstrap .navbar .btn {
@@ -2560,7 +2526,7 @@
     text-decoration: none; }
   .bootstrap .navbar .nav .active > a,
   .bootstrap .navbar .nav .active > a:hover {
-    color: #222222;
+    color: #222;
     text-decoration: none;
     background-color: #ffcc20; }
   .bootstrap .navbar .divider-vertical {
@@ -2568,8 +2534,8 @@
     width: 1px;
     margin: 0 9px;
     overflow: hidden;
-    background-color: #222222;
-    border-right: 1px solid #555555; }
+    background-color: #222;
+    border-right: 1px solid #555; }
   .bootstrap .navbar .nav.pull-right {
     margin-left: 10px;
     margin-right: 0; }
@@ -2580,24 +2546,24 @@
     margin-left: 5px;
     margin-right: 5px;
     background-color: #404040;
-    background-image: -moz-linear-gradient(top, #555555, #222222);
-    background-image: -ms-linear-gradient(top, #555555, #222222);
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#555555), to(#222222));
-    background-image: -webkit-linear-gradient(top, #555555, #222222);
-    background-image: -o-linear-gradient(top, #555555, #222222);
-    background-image: linear-gradient(top, #555555, #222222);
+    background-image: -moz-linear-gradient(top, #555, #222);
+    background-image: -ms-linear-gradient(top, #555, #222);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#555), to(#222));
+    background-image: -webkit-linear-gradient(top, #555, #222);
+    background-image: -o-linear-gradient(top, #555, #222);
+    background-image: linear-gradient(top, #555, #222);
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#525252', endColorstr='#1f1f1f', GradientType=0);
-    border-color: #222222 #222222 black;
+    border-color: #222 #222 black;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-    *background-color: #222222;
+    *background-color: #222;
     /* Darken IE7 buttons by default so they stand out more given they won't have borders */
     filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
     -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.075);
     -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.075);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.075); }
     .bootstrap .navbar .btn-navbar:hover, .bootstrap .navbar .btn-navbar:active, .bootstrap .navbar .btn-navbar.active, .bootstrap .navbar .btn-navbar.disabled, .bootstrap .navbar .btn-navbar[disabled] {
-      background-color: #222222;
+      background-color: #222;
       *background-color: #151515; }
     .bootstrap .navbar .btn-navbar:active, .bootstrap .navbar .btn-navbar.active {
       background-color: #090909 \9; }
@@ -2629,7 +2595,7 @@
     display: inline-block;
     border-left: 6px solid transparent;
     border-right: 6px solid transparent;
-    border-bottom: 6px solid white;
+    border-bottom: 6px solid #fff;
     position: absolute;
     top: -6px;
     left: 10px; }
@@ -2640,14 +2606,14 @@
     bottom: -7px;
     top: auto; }
   .bootstrap .navbar-fixed-bottom .dropdown-menu:after {
-    border-top: 6px solid white;
+    border-top: 6px solid #fff;
     border-bottom: 0;
     bottom: -6px;
     top: auto; }
   .bootstrap .navbar .nav li.dropdown .dropdown-toggle .caret,
   .bootstrap .navbar .nav li.dropdown.open .caret {
-    border-top-color: white;
-    border-bottom-color: white; }
+    border-top-color: #fff;
+    border-bottom-color: #fff; }
   .bootstrap .navbar .nav li.dropdown.active .caret {
     opacity: 1;
     filter: alpha(opacity=100); }
@@ -2656,7 +2622,7 @@
   .bootstrap .navbar .nav li.dropdown.open.active > .dropdown-toggle {
     background-color: transparent; }
   .bootstrap .navbar .nav li.dropdown.active > .dropdown-toggle:hover {
-    color: white; }
+    color: #fff; }
   .bootstrap .navbar .pull-right .dropdown-menu,
   .bootstrap .navbar .dropdown-menu.pull-right {
     left: auto;
@@ -2676,31 +2642,31 @@
     margin: 0 0 20px;
     list-style: none;
     background-color: #fbfbfb;
-    background-image: -moz-linear-gradient(top, white, whitesmoke);
-    background-image: -ms-linear-gradient(top, white, whitesmoke);
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(white), to(whitesmoke));
-    background-image: -webkit-linear-gradient(top, white, whitesmoke);
-    background-image: -o-linear-gradient(top, white, whitesmoke);
-    background-image: linear-gradient(top, white, whitesmoke);
+    background-image: -moz-linear-gradient(top, #fff, #f5f5f5);
+    background-image: -ms-linear-gradient(top, #fff, #f5f5f5);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#fff), to(#f5f5f5));
+    background-image: -webkit-linear-gradient(top, #fff, #f5f5f5);
+    background-image: -o-linear-gradient(top, #fff, #f5f5f5);
+    background-image: linear-gradient(top, #fff, #f5f5f5);
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f2f2f2', GradientType=0);
     border: 1px solid #ddd;
     -webkit-border-radius: 3px;
     -moz-border-radius: 3px;
     border-radius: 3px;
-    -webkit-box-shadow: inset 0 1px 0 white;
-    -moz-box-shadow: inset 0 1px 0 white;
-    box-shadow: inset 0 1px 0 white; }
+    -webkit-box-shadow: inset 0 1px 0 #fff;
+    -moz-box-shadow: inset 0 1px 0 #fff;
+    box-shadow: inset 0 1px 0 #fff; }
     .bootstrap .breadcrumb li {
       display: inline-block;
       *display: inline;
       *zoom: 1;
-      text-shadow: 0 1px 0 white; }
+      text-shadow: 0 1px 0 #fff; }
     .bootstrap .breadcrumb .divider {
       padding: 0 5px;
-      color: #999999; }
+      color: #999; }
     .bootstrap .breadcrumb .active a {
-      color: #333333; }
+      color: #333; }
   .bootstrap .pagination {
     height: 40px;
     margin: 20px 0; }
@@ -2729,12 +2695,12 @@
   .bootstrap .pagination .active a {
     background-color: #f5f5f5; }
   .bootstrap .pagination .active a {
-    color: #999999;
+    color: #999;
     cursor: default; }
   .bootstrap .pagination .disabled span,
   .bootstrap .pagination .disabled a,
   .bootstrap .pagination .disabled a:hover {
-    color: #999999;
+    color: #999;
     background-color: transparent;
     cursor: default; }
   .bootstrap .pagination li:first-child a {
@@ -2780,7 +2746,7 @@
     float: left; }
   .bootstrap .pager .disabled a,
   .bootstrap .pager .disabled a:hover {
-    color: #999999;
+    color: #999;
     background-color: #fff;
     cursor: default; }
   .bootstrap .modal-open .dropdown-menu {
@@ -2798,7 +2764,7 @@
     bottom: 0;
     left: 0;
     z-index: 1040;
-    background-color: black; }
+    background-color: #000; }
     .bootstrap .modal-backdrop.fade {
       opacity: 0; }
   .bootstrap .modal-backdrop,
@@ -2813,7 +2779,7 @@
     overflow: auto;
     width: 560px;
     margin: -250px 0 0 -280px;
-    background-color: white;
+    background-color: #fff;
     border: 1px solid #999;
     border: 1px solid rgba(0, 0, 0, 0.3);
     *border: 1px solid #999;
@@ -2856,9 +2822,9 @@
     -webkit-border-radius: 0 0 6px 6px;
     -moz-border-radius: 0 0 6px 6px;
     border-radius: 0 0 6px 6px;
-    -webkit-box-shadow: inset 0 1px 0 white;
-    -moz-box-shadow: inset 0 1px 0 white;
-    box-shadow: inset 0 1px 0 white;
+    -webkit-box-shadow: inset 0 1px 0 #fff;
+    -moz-box-shadow: inset 0 1px 0 #fff;
+    box-shadow: inset 0 1px 0 #fff;
     *zoom: 1; }
     .bootstrap .modal-footer:before, .bootstrap .modal-footer:after {
       display: table;
@@ -2891,28 +2857,28 @@
       margin-left: -5px;
       border-left: 5px solid transparent;
       border-right: 5px solid transparent;
-      border-top: 5px solid black; }
+      border-top: 5px solid #000; }
     .bootstrap .popover.right .arrow {
       top: 50%;
       left: 0;
       margin-top: -5px;
       border-top: 5px solid transparent;
       border-bottom: 5px solid transparent;
-      border-right: 5px solid black; }
+      border-right: 5px solid #000; }
     .bootstrap .popover.bottom .arrow {
       top: 0;
       left: 50%;
       margin-left: -5px;
       border-left: 5px solid transparent;
       border-right: 5px solid transparent;
-      border-bottom: 5px solid black; }
+      border-bottom: 5px solid #000; }
     .bootstrap .popover.left .arrow {
       top: 50%;
       right: 0;
       margin-top: -5px;
       border-top: 5px solid transparent;
       border-bottom: 5px solid transparent;
-      border-left: 5px solid black; }
+      border-left: 5px solid #000; }
     .bootstrap .popover .arrow {
       position: absolute;
       width: 0;
@@ -2921,7 +2887,7 @@
     padding: 3px;
     width: 280px;
     overflow: hidden;
-    background: black;
+    background: #000;
     background: rgba(0, 0, 0, 0.8);
     -webkit-border-radius: 6px;
     -moz-border-radius: 6px;
@@ -2939,7 +2905,7 @@
     border-radius: 3px 3px 0 0; }
   .bootstrap .popover-content {
     padding: 14px;
-    background-color: white;
+    background-color: #fff;
     -webkit-border-radius: 0 0 3px 3px;
     -moz-border-radius: 0 0 3px 3px;
     border-radius: 0 0 3px 3px;
@@ -2991,11 +2957,11 @@
     font-size: 12.69px;
     font-weight: bold;
     line-height: 14px;
-    color: white;
+    color: #fff;
     vertical-align: baseline;
     white-space: nowrap;
     text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
-    background-color: #999999; }
+    background-color: #999; }
   .bootstrap .label {
     padding: 1px 4px 2px;
     -webkit-border-radius: 3px;
@@ -3007,7 +2973,7 @@
     -moz-border-radius: 9px;
     border-radius: 9px; }
   .bootstrap a.label:hover, .bootstrap a.badge:hover {
-    color: white;
+    color: #fff;
     text-decoration: none;
     cursor: pointer; }
   .bootstrap .label-important, .bootstrap .badge-important {
@@ -3027,20 +2993,45 @@
   .bootstrap .label-info[href], .bootstrap .badge-info[href] {
     background-color: #2d6987; }
   .bootstrap .label-inverse, .bootstrap .badge-inverse {
-    background-color: #333333; }
+    background-color: #333; }
   .bootstrap .label-inverse[href], .bootstrap .badge-inverse[href] {
     background-color: #1a1a1a; }
+@-webkit-keyframes progress-bar-stripes {
+  from {
+    background-position: 40px 0; }
+  to {
+    background-position: 0 0; } }
+@-moz-keyframes progress-bar-stripes {
+  from {
+    background-position: 40px 0; }
+  to {
+    background-position: 0 0; } }
+@-ms-keyframes progress-bar-stripes {
+  from {
+    background-position: 40px 0; }
+  to {
+    background-position: 0 0; } }
+@-o-keyframes progress-bar-stripes {
+  from {
+    background-position: 0 0; }
+  to {
+    background-position: 40px 0; } }
+@keyframes progress-bar-stripes {
+  from {
+    background-position: 40px 0; }
+  to {
+    background-position: 0 0; } }
   .bootstrap .progress {
     overflow: hidden;
     height: 18px;
     margin-bottom: 18px;
     background-color: #f6f6f6;
-    background-image: -moz-linear-gradient(top, whitesmoke, #f9f9f9);
-    background-image: -ms-linear-gradient(top, whitesmoke, #f9f9f9);
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(whitesmoke), to(#f9f9f9));
-    background-image: -webkit-linear-gradient(top, whitesmoke, #f9f9f9);
-    background-image: -o-linear-gradient(top, whitesmoke, #f9f9f9);
-    background-image: linear-gradient(top, whitesmoke, #f9f9f9);
+    background-image: -moz-linear-gradient(top, #f5f5f5, #f9f9f9);
+    background-image: -ms-linear-gradient(top, #f5f5f5, #f9f9f9);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f5f5f5), to(#f9f9f9));
+    background-image: -webkit-linear-gradient(top, #f5f5f5, #f9f9f9);
+    background-image: -o-linear-gradient(top, #f5f5f5, #f9f9f9);
+    background-image: linear-gradient(top, #f5f5f5, #f9f9f9);
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f2f2f2', endColorstr='#f6f6f6', GradientType=0);
     -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
@@ -3052,7 +3043,7 @@
   .bootstrap .progress .bar {
     width: 0%;
     height: 18px;
-    color: white;
+    color: #fff;
     font-size: 12px;
     text-align: center;
     text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
@@ -3236,10 +3227,10 @@
     font-size: 60px;
     font-weight: 100;
     line-height: 30px;
-    color: white;
+    color: #fff;
     text-align: center;
-    background: #222222;
-    border: 3px solid white;
+    background: #222;
+    border: 3px solid #fff;
     -webkit-border-radius: 23px;
     -moz-border-radius: 23px;
     border-radius: 23px;
@@ -3249,7 +3240,7 @@
       left: auto;
       right: 15px; }
     .bootstrap .carousel-control:hover {
-      color: white;
+      color: #fff;
       text-decoration: none;
       opacity: 0.9;
       filter: alpha(opacity=90); }
@@ -3259,15 +3250,15 @@
     right: 0;
     bottom: 0;
     padding: 10px 15px 5px;
-    background: #333333;
+    background: #333;
     background: rgba(0, 0, 0, 0.75); }
   .bootstrap .carousel-caption h4,
   .bootstrap .carousel-caption p {
-    color: white; }
+    color: #fff; }
   .bootstrap .hero-unit {
     padding: 60px;
     margin-bottom: 30px;
-    background-color: #eeeeee;
+    background-color: #eee;
     -webkit-border-radius: 6px;
     -moz-border-radius: 6px;
     border-radius: 6px; }
@@ -3320,37 +3311,37 @@
     margin-left: -5px;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-top: 5px solid black; }
+    border-top: 5px solid #000; }
   .tooltip.left .tooltip-arrow {
     top: 50%;
     right: 0;
     margin-top: -5px;
     border-top: 5px solid transparent;
     border-bottom: 5px solid transparent;
-    border-left: 5px solid black; }
+    border-left: 5px solid #000; }
   .tooltip.bottom .tooltip-arrow {
     top: 0;
     left: 50%;
     margin-left: -5px;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-bottom: 5px solid black; }
+    border-bottom: 5px solid #000; }
   .tooltip.right .tooltip-arrow {
     top: 50%;
     left: 0;
     margin-top: -5px;
     border-top: 5px solid transparent;
     border-bottom: 5px solid transparent;
-    border-right: 5px solid black; }
+    border-right: 5px solid #000; }
 
 .tooltip-inner {
   max-width: 200px;
   padding: 3px 8px;
-  color: white;
+  color: #fff;
   line-height: 20px;
   text-align: center;
   text-decoration: none;
-  background-color: black;
+  background-color: #000;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px; }
@@ -3359,3 +3350,5 @@
   position: absolute;
   width: 0;
   height: 0; }
+
+/*# sourceMappingURL=ttstrap.css.map */

--- a/tx_highered/static/tx_highered/vendor/bootstrap/scss/_forms.scss
+++ b/tx_highered/static/tx_highered/vendor/bootstrap/scss/_forms.scss
@@ -392,6 +392,7 @@ select:focus:required:invalid {
     border-left-color: #ccc;
   }
   .add-on {
+    box-sizing: content-box;
     display: inline-block;
     width: auto;
     height: $baseLineHeight;


### PR DESCRIPTION
#### What's this PR do?
Add box-sizing of content-box to .add-on to fix box-sizing of border-box currently making buttons render not as intended.

#### Why are we doing this? How does it help us?
Gets us ready for Higher Ed Explorer pointer.

#### How should this be manually tested?
Run locally, inspect elements, and when you check out .add-on, you should see 'box-sizing: content-box' as a style for it. What I did was then go to http://www.texastribune.org/higher-ed/explore/, inspect elements there, insert 'box-sizing: content-box' to .add-on in dev tools, and visually confirm that adding this 'box-sizing: content-box' style fixes the buttons.

#### What are the relevant tickets?
Email ask from Rodney.

#### Next steps?
Get Chris to transfer over ownership of tx_highered on PyPi.
Bump version and run `make release` on master to push the new version to PyPi.

#### Smells?

#### TODOs:

#### Has the relevant documentation/wiki been updated?

#### Technical debt note