### PR TITLE
rm references to glossary lib

### DIFF
--- a/exampleproject/settings/base.py
+++ b/exampleproject/settings/base.py
@@ -131,7 +131,6 @@ INSTALLED_APPS = [
     'django_object_actions',
 
     # app
-    'glossary',
     'tx_lege_districts',
     'tx_highered',
     'tx_highered.instachart',

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ project-runpy==0.3.1
 psycopg2
 django-object-actions==0.5.0
 django-extensions
-https://github.com/texastribune/tt-glossary/archive/master.tar.gz
 Pillow==2.5.3
 geopy
 # DELETEME make this an api call instead of a database integration

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='tx_highered',
-    version='0.3.8.dev2',
+    version='0.3.8.dev3',
     description='Django app for Texas higher education data',
     author='Texas Tribune',
     author_email='tech@texastribune.org',

--- a/tx_highered/templates/tx_highered/includes/attribution.html
+++ b/tx_highered/templates/tx_highered/includes/attribution.html
@@ -1,20 +1,17 @@
-{% load glossary %}
 <p>
   <i class="icon-info-sign"></i> Data from the
   {% if object.is_private %}
-    {% gloss "IPEDS" %}
+    IPEDS
     <a href="http://nces.ed.gov/ipeds/datacenter/">Data Center</a>
-    and the
-    {% gloss "THECB" %}
+    and the THECB
     <a href="http://www.txhighereddata.org/approot/dwprodrpt/enrmenu.htm">
       <abbr title="Profile Reports Electronically Produced">PREP</abbr>
       enrollment report
     </a>
   {% else %}
-    {% gloss "IPEDS" %}
+    IPEDS
     <a href="http://nces.ed.gov/ipeds/datacenter/">Data Center</a>
-    and the
-    {% gloss "THECB" %}
+    and the THECB
     <a href="http://www.txhighereddata.org/approot/dwprodrpt/enrmenu.htm">
       <abbr title="Profile Reports Electronically Produced">PREP</abbr>
       enrollment report

--- a/tx_highered/templates/tx_highered/institution_detail.html
+++ b/tx_highered/templates/tx_highered/institution_detail.html
@@ -1,12 +1,11 @@
 {% extends "tx_highered/detail_base.html" %}
-{% load glossary %}
 {% load layout_helpers humanize instachart %}
 {% load static from staticfiles %}
 
 {% block head_title %}{{ object.name }}{% endblock %}
 {% block page_title %}{{ object.name }}{% endblock %}
 
-{% block body_base %}{% load_glossary "Higher Ed" %}{{ block.super }}{% endblock %}
+{% block body_base %}{{ block.super }}{% endblock %}
 
 {% block breadcrumb_items %}
   {% if object.system %}
@@ -46,7 +45,7 @@
 
   {% if institution.sentence_institution_type %}
     <p class="rollup">
-        {% gloss institution.sentence_institution_type.title %}
+        {{ institution.sentence_institution_type.title }}
     </p>
   {% endif %}
 
@@ -97,17 +96,17 @@
 
         <tbody>
           <tr>
-            <th>{% gloss "Applicants" %}</th>
+            <th>Applicants</th>
             {% for a in object.admission_buckets.applicants.values %}<td>{{ a|intcomma }}</td>{% endfor %}
           </tr>
 
           <tr>
-            <th>{% gloss "Admitted" %}<br><small>(% of Applicants)</small></th>
+            <th>Admitted<br><small>(% of Applicants)</small></th>
             {% for a in object.admission_buckets.admitted.values %}<td>{{ a.0|intcomma }} <small>({{ a.1 }}%)</small></td>{% endfor %}
           </tr>
 
           <tr>
-            <th>{% gloss "Enrolled" %}<br><small>(% of Admitted)</small></th>
+            <th>Enrolledbr><small>(% of Admitted)</small></th>
             {% for a in object.admission_buckets.enrolled.values %}<td>{{ a.0|intcomma }} <small>({{ a.1 }}%)</small></td>{% endfor %}
           </tr>
         </tbody>
@@ -145,7 +144,7 @@
     <div class="row">
       <div class="span12">
         <div class="well well-small chart-help">
-          Average {% gloss "SAT" %} scores by section for enrolling students (writing section not introduced until 2006 and still not reported by some institutions)
+          Average scores by section for enrolling students (writing section not introduced until 2006 and still not reported by some institutions)
         </div>
       </div>
     </div>
@@ -309,23 +308,23 @@
             </tr>
             {% if b.pacific_islander_percent %}
               <tr>
-                <th>{% gloss "Pacific Islander" %}</th>
+                <th>Pacific Islander</th>
                 {% for a in b.pacific_islander_percent.values %}<td>{% if a %}{{ a }}%{% else %}*{% endif %}</td>{% endfor %}
               </tr>
             {% endif %}
             <tr>
-              <th>{% gloss "Native" %}</th>
+              <th>Native</th>
               {% for a in b.total_percent_native.values %}<td>{% if a %}{{ a }}%{% else %}*{% endif %}</td>{% endfor %}
             </tr>
             {% if b.multiracial_percent %}
               <tr>
-                <th>{% gloss "Multiracial" %}</th>
+                <th>Multiracial</th>
                 {% for a in b.multiracial_percent.values %}<td>{% if a %}{{ a }}%{% else %}*{% endif %}</td>{% endfor %}
               </tr>
             {% endif %}
             {% if b.international_percent %}
               <tr>
-                <th>{% gloss "International" %}</th>
+                <th>International</th>
                 {% for a in b.international_percent.values %}<td>{% if a %}{{ a }}%{% else %}*{% endif %}</td>{% endfor %}
               </tr>
             {% endif %}
@@ -370,7 +369,7 @@
     <div class="row">
       <div class="span12">
         <div class="well well-small chart-help">
-          Average total cost for {% gloss "in-state" %} and {% gloss "out-of-state" %} students by year
+          Average total cost for in-state and out-of-state students by year
           <small class="data_source invisible">
             Source: IPEDS
           </small>
@@ -391,7 +390,7 @@
         </thead>
         <tbody>
           <tr>
-            <th>{% gloss "In-State" %} Tuition</th>
+            <th>In-State Tuition</th>
             {% for a in object.tuition_buckets.in_state.values %}
               <td>
                 {% if a %}
@@ -403,7 +402,7 @@
             {% endfor %}
           </tr>
           <tr>
-            <th>{% gloss "Out-Of-State" %} Tuition</th>
+            <th>Out-Of-State Tuition</th>
             {% for a in object.tuition_buckets.out_of_state.values %}
               <td>
                 {% if a %}
@@ -502,7 +501,7 @@
         <div class="span12">
           <div class="chart-help well well-small">
             <!-- mentally remove the inline comment if you prefer proper English -->
-            Percent of {% gloss "first-time" %}, full-time students who graduated in four, five<!--, --> or six years
+            Percent of first-time full-time students who graduated in four, five<!--, --> or six years
             {% if b.data_source %}
               <small class="data_source invisible">
                 Source: {{ b.data_source }}
@@ -543,7 +542,7 @@
         <div class="row requires-svg">
           <div class="span12">
             <div class="well well-small chart-help">
-              Percent of {% gloss "first-time" %}, full-time students who graduated in four, five<!--, --> or six years
+              Percent of first-time, full-time students who graduated in four, five or six years
             </div>
           </div>
         </div>

--- a/tx_highered/templates/tx_highered/institution_detail.html
+++ b/tx_highered/templates/tx_highered/institution_detail.html
@@ -106,7 +106,7 @@
           </tr>
 
           <tr>
-            <th>Enrolledbr><small>(% of Admitted)</small></th>
+            <th>Enrolled<br><small>(% of Admitted)</small></th>
             {% for a in object.admission_buckets.enrolled.values %}<td>{{ a.0|intcomma }} <small>({{ a.1 }}%)</small></td>{% endfor %}
           </tr>
         </tbody>


### PR DESCRIPTION
#### What's this PR do?
Removes glossary library references

#### Why are we doing this? How does it help us?
Allows us to remove glossary from `texastribune`

#### How should this be manually tested?
N/A

#### Have automated tests been added?
N/A

#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?
N/A

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/273814580

#### How should this change be communicated to end users?
N/A

#### Next steps?
N/A

#### Smells?
N/A

#### Has the relevant documentation/wiki been updated?
N/A

#### Technical debt note
Slightly reduced

